### PR TITLE
Add 'fix' and configure commands

### DIFF
--- a/confman.py
+++ b/confman.py
@@ -497,6 +497,8 @@ def main():
         logging.critical(f"Subcommand {args.command} crashed.")
         print("It appears that one or more group has a malformed 'group.toml' file.")
         print("Try running\n    $ [confman] fix\nto add missing fields to config files.")
+        print("After running `fix`, you can (optionally) run\n    $ [confman] configure <group>")
+        print("to manually set the fields in the group's 'group.toml' file.")
         print("Don't worry, this error is completely normal after a confman update.")
         print("This also might have occurred because you made a mistake manually editing the file.")
 

--- a/confman.py
+++ b/confman.py
@@ -205,9 +205,9 @@ def command_list(verbose: bool):
             else:
                 configs_count += 1
 
-        msg = f"* ({group}) | {group_cfg_data['desc']} | {configs_count} config(s)"
+        msg = f"* {group} | desc: '{group_cfg_data['desc']}' | config(s): {configs_count}"
         if verbose:
-            msg += f" | swaps to {group_cfg_data['dest_path']}"
+            msg += f" | swap dest: '{group_cfg_data['dest_path']}'"
 
         print(msg, end="")
 
@@ -220,7 +220,7 @@ def command_fix(verbose: bool):
     """Fix missing fields in 'group.toml' files"""
     for group in os.listdir(GROUPS_PATH):
         if verbose:
-            print(f"Fixing {group}")
+            print(f"Fixing {group}...")
         group_path = os.path.join(GROUPS_PATH, group)
         changes_made = False
         group_cfg_path = os.path.join(group_path, GROUP_CFG_FN)
@@ -245,8 +245,36 @@ def command_fix(verbose: bool):
                 toml.dump(group_cfg_data, f)
         else:
             if verbose:
-                print(f"No fixes were found for group {group}")
+                print(f"No fixes were found for group {group}.")
 
+def command_configure(group: str):
+    group_path = os.path.join(GROUPS_PATH, group)
+    group_cfg_path = os.path.join(group_path, GROUP_CFG_FN)
+    try:
+        group_cfg_data = toml.load(group_cfg_path)
+    except FileNotFoundError:
+        logging.critical(f"No config file was found at {group_cfg_path}")
+        print("Try running\n    $ [confman] fix\nto automatically create it")
+        sys.exit(1)
+
+    print("Welcome to the confman group configuration wizard.")
+    print("For each field in the group.toml file, you will be prompted to either:")
+    print("    * Type a new value and press enter")
+    print("    * Press ctrl+d to keep the value the same")
+    for key in group_cfg_data:
+        value = group_cfg_data[key]
+        print(f"'{key}'='{value}'")
+        try:
+            new_value = input(">")
+            print(f"Updated: '{key}'='{new_value}'")
+        except EOFError:
+            new_value = value
+            print("[ctrl+d]\nValue not updated")
+        group_cfg_data[key] = new_value
+
+    print(f"Configuration complete. Writing to {group_cfg_path}")
+    with open(group_cfg_path, "w") as f:
+        toml.dump(group_cfg_data, f)
 
 def command_swap(group: str, config: str):
     """Swap configs for a certain group"""
@@ -409,6 +437,17 @@ def main():
         action="store_true",
     )
 
+    configure_parser = subparsers.add_parser(
+        "configure",
+        help="configure settings of a group"
+    )
+
+    configure_parser.add_argument(
+        "name",
+        help="the name of the group to configure",
+        type=str,
+    )
+
     swap_parser = subparsers.add_parser(
         "swap",
         help="swap between configs",
@@ -448,12 +487,15 @@ def main():
                 command_list(args.verbose)
             case "fix":
                 command_fix(args.verbose)
+            case "configure":
+                command_configure(args.name)
             case "swap":
                 command_swap(args.group, args.config)
             case _:
                 assert False, f"Unreachable [command {args.command}](please report this issue on github)"
     except KeyError:
-        logging.critical("It appears that one or more group has a malformed 'group.toml' file.")
+        logging.critical(f"Subcommand {args.command} crashed.")
+        print("It appears that one or more group has a malformed 'group.toml' file.")
         print("Try running\n    $ [confman] fix\nto add missing fields to config files.")
         print("Don't worry, this error is completely normal after a confman update.")
         print("This also might have occurred because you made a mistake manually editing the file.")


### PR DESCRIPTION
Adds the `desc` field to group.toml files, which is a description of the group that is shown in the `list` command with each group.

Adds the
```
$ [confman] fix
```
command to fill in missing fields in group.toml files for every group automatically. Also adds better error handling for missing fields in config files, suggesting that the user run the `fix` and `configure` commands.

Adds the
```
$ [confman] configure <group>
```
command, to configure the group.toml file for a specific group.