### PR TITLE
Add 'unswap' command and fix 'list -g' bug

### DIFF
--- a/conswap.py
+++ b/conswap.py
@@ -210,14 +210,17 @@ def command_delete(name: str):
         )
 
 def dir_size(path: str):
-    total_size = 0
-    for dirpath, dirnames, filenames in os.walk(path):
-        for f in filenames:
-            fp = os.path.join(dirpath, f)
-            if not os.path.islink(fp):
-                total_size += os.path.getsize(fp)
+    if os.path.isdir(path):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                if not os.path.islink(fp):
+                    total_size += os.path.getsize(fp)
 
-    return total_size
+        return total_size
+    else:
+        return os.path.getsize(path)
 
 def size_fmt(bytes: int):
     size:float = float(bytes)


### PR DESCRIPTION
Add the 'unswap' command to remove any swapped config from a group (deletes the symlink to a config, leaving no file at the destination path for a group).

Fix a bug in the 'list' command: When listing a group with 'list -g', configs that were files and not folders would have their sizes shown as 0 bytes. This is now fixed, and file sizes are shown correctly.